### PR TITLE
Add Feature: Right-Alignment

### DIFF
--- a/src/client/java/io/github/ueva/cluescrollhud/config/ModConfig.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/config/ModConfig.java
@@ -21,6 +21,9 @@ public class ModConfig implements ConfigData {
     @ConfigEntry.Category("Display")
     public float smallTextScale = 0.70f;
 
+    @ConfigEntry.Category("Display")
+    public boolean rightAlign = false;
+
     // Position of the top-left corner of the HUD.
     @ConfigEntry.Category("Display")
     public float x = 0.0f;

--- a/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollManager.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollManager.java
@@ -75,6 +75,9 @@ public class ClueScrollManager {
                 LOGGER.info("Removed clue scroll from list: {}", scroll.getUuid());
             }
         }
+
+        // Ensure the selected index is valid.
+        updateSelectedIndex();
     }
 
     public List<ClueScroll> getScrolls() {

--- a/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollRenderer.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollRenderer.java
@@ -19,6 +19,8 @@ public class ClueScrollRenderer {
     private static final int SPACING = 5;
     private final ModConfig config;
 
+    private int cachedMaxTextWidth = 0;
+
     public ClueScrollRenderer(ModConfig config) {
         this.config = config;
     }
@@ -57,10 +59,13 @@ public class ClueScrollRenderer {
 
         int clueCount = selectedScroll.getClueCount();
         int maxTextWidth = 0;
+
         int cursorY = MARGIN + PADDING;
 
         // Track where the top-left of the content begins
-        int contentLeft = MARGIN + PADDING;
+        int contentLeft = config.rightAlign ?
+                context.getScaledWindowWidth() - (MARGIN + PADDING + cachedMaxTextWidth) :
+                MARGIN + PADDING;
 
         // ─── Draw "Scroll X of Y" ──────────────────────────────────────────────
         matrices.push();
@@ -172,11 +177,14 @@ public class ClueScrollRenderer {
 
         cursorY += (int) (textRenderer.fontHeight * smallTextScale);
 
+        cachedMaxTextWidth = maxTextWidth;
+
         // ─── Draw Background ──────────────────────────────────────────────
         int backgroundRight = contentLeft + maxTextWidth + PADDING;
         int backgroundBottom = cursorY + PADDING;
 
-        context.fill(MARGIN, MARGIN, backgroundRight, backgroundBottom, 0x7F000000);
+        context.fill(contentLeft - PADDING, MARGIN, backgroundRight, backgroundBottom, 0x7F000000);
+
     }
 
     public void renderNoClueScrolls(DrawContext context, TextRenderer textRenderer) {
@@ -191,17 +199,20 @@ public class ClueScrollRenderer {
         int textWidth = textRenderer.getWidth(text);
         int textHeight = textRenderer.fontHeight;
 
+        int contentLeft =
+                config.rightAlign ? context.getScaledWindowWidth() - (MARGIN + PADDING + textWidth + PADDING) : MARGIN;
+
         // Render the background.
         context.fill(
+                contentLeft,
                 MARGIN,
-                MARGIN,
-                MARGIN + PADDING + textWidth + PADDING,
+                contentLeft + PADDING + textWidth + PADDING,
                 MARGIN + PADDING + textHeight + PADDING,
                 0,
                 0x7F000000
         );
 
         // Draw the "no cluescrolls" message.
-        context.drawTextWithShadow(textRenderer, text, MARGIN + PADDING, MARGIN + PADDING, 0xFFFFFF);
+        context.drawTextWithShadow(textRenderer, text, contentLeft + PADDING, MARGIN + PADDING, 0xFFFFFF);
     }
 }

--- a/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollRenderer.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollRenderer.java
@@ -33,8 +33,8 @@ public class ClueScrollRenderer {
         // Apply global scale and offset from config.
         MatrixStack matrices = context.getMatrices();
         matrices.push();
-        matrices.scale(config.globalScale, config.globalScale, 1.0f);
         matrices.translate(config.x, config.y, 0.0f);
+        matrices.scale(config.globalScale, config.globalScale, 1.0f);
 
         // Render the currently selected scroll.
         if (totalScrolls > 0) {
@@ -53,7 +53,7 @@ public class ClueScrollRenderer {
         int maxTextWidth = measureMaxTextWidth(textRenderer, selectedScroll, selectedIndex, totalScrolls);
 
         int contentLeft = config.rightAlign ?
-                context.getScaledWindowWidth() - (MARGIN + PADDING + maxTextWidth) :
+                (int) (context.getScaledWindowWidth() / config.globalScale) - (MARGIN + PADDING + maxTextWidth) :
                 MARGIN + PADDING;
 
         renderClueScrollContent(
@@ -247,8 +247,9 @@ public class ClueScrollRenderer {
         int textWidth = textRenderer.getWidth(text);
         int textHeight = textRenderer.fontHeight;
 
-        int contentLeft =
-                config.rightAlign ? context.getScaledWindowWidth() - (MARGIN + PADDING + textWidth + PADDING) : MARGIN;
+        int contentLeft = config.rightAlign ?
+                (int) (context.getScaledWindowWidth() / config.globalScale) - (MARGIN + PADDING + textWidth + PADDING) :
+                MARGIN;
 
         // Render the background.
         context.fill(

--- a/src/main/resources/assets/vg-cluescrollhud/lang/en_us.json
+++ b/src/main/resources/assets/vg-cluescrollhud/lang/en_us.json
@@ -13,6 +13,7 @@
   "text.autoconfig.vg-cluescrollhud.option.hideCompleted": "Hide Completed Clue Tasks",
   "text.autoconfig.vg-cluescrollhud.option.updateInterval": "HUD Update Interval (milliseconds)",
   "text.autoconfig.vg-cluescrollhud.option.colourByProgress": "Colour Clue Text by Progress",
+  "text.autoconfig.vg-cluescrollhud.option.rightAlign": "Right-Align HUD",
   "text.autoconfig.vg-cluescrollhud.category.Display": "Display",
   "text.autoconfig.vg-cluescrollhud.category.Behaviour": "Behaviour"
 }


### PR DESCRIPTION
Added support for aligning the HUD element to the right-hand side of the screen.

Additionally, this pull request fixes a crash that occurred when the player dropped their highest-indexed clue scroll while having it showing on the HUD, and improved the behaviour of the global offset and scaling options.

This pull requests implements Issue #8.