### PR TITLE
Feature: Fetch Extended Scroll Expiry Time from API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     modApi("com.terraformersmc:modmenu:${project.modmenu_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
+
+    // Google Gson.
+    modImplementation "com.google.code.gson:gson:${project.gson_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ archives_base_name=vg-cluescrollhud
 fabric_version=0.119.2+1.21.4
 cloth_version=17.0.144
 modmenu_version=13.0.2
+gson_version=2.13.1

--- a/src/client/java/io/github/ueva/cluescrollhud/VgClueScrollHUDClient.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/VgClueScrollHUDClient.java
@@ -4,6 +4,7 @@ import io.github.ueva.cluescrollhud.commands.CommandRegistrar;
 import io.github.ueva.cluescrollhud.config.ModConfig;
 import io.github.ueva.cluescrollhud.hudelement.HudElementRegistrar;
 import io.github.ueva.cluescrollhud.keybinds.KeybindRegistrar;
+import io.github.ueva.cluescrollhud.net.RemoteDataFetcher;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
@@ -33,11 +34,15 @@ public class VgClueScrollHUDClient implements ClientModInitializer {
         KeybindRegistrar.registerKeybinds();
         LOGGER.info("...finished registering all keybinds!");
 
-
         // Register commands.
         LOGGER.info("Registering commands...");
         CommandRegistrar.registerCommands();
         LOGGER.info("...finished registering all commands.");
+
+        // Get dynamic data from the API.
+        LOGGER.info("Requesting dynamic data from the API...");
+        RemoteDataFetcher.fetchAll();
+        LOGGER.info("...finished requesting dynamic data from the API!");
     }
 }
 

--- a/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollParser.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/hudelement/ClueScrollParser.java
@@ -2,6 +2,7 @@ package io.github.ueva.cluescrollhud.hudelement;
 
 import io.github.ueva.cluescrollhud.models.ClueScroll;
 import io.github.ueva.cluescrollhud.models.ClueTask;
+import io.github.ueva.cluescrollhud.net.RemoteDataFetcher;
 import io.github.ueva.cluescrollhud.utils.TierNameUtils;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.NbtComponent;
@@ -16,9 +17,18 @@ public class ClueScrollParser {
     public static ClueScroll parseScrollData(NbtCompound scrollData, int invPosition) {
         // Extract the scroll's UUID, tier, created time, and expiration time.
         String uuid = scrollData.getString("ClueScrolls.uuid");
-        String tier = TierNameUtils.sanitiseTierName(scrollData.getString("ClueScrolls.tier"));
+        String tier = TierNameUtils.sanitiseTierName(scrollData.getString("ClueScrolls.tier")).toLowerCase();
         long created = scrollData.getLong("ClueScrolls.created");
-        long expire = scrollData.getLong("ClueScrolls.expire");
+
+        // If the scroll's tier is "Extended", use the expiry time from the remote data fetcher, otherwise use the
+        // one from the scroll data.
+        long expire = -1L;
+        if (tier.equals("extended")) {
+            expire = RemoteDataFetcher.getExtendedExpiryTime();
+        }
+        else {
+            expire = scrollData.getLong("ClueScrolls.expire");
+        }
 
         // Extract the clues from the NBT data.
         ArrayList<ClueTask> clues = new ArrayList<>();

--- a/src/client/java/io/github/ueva/cluescrollhud/net/RemoteDataFetcher.java
+++ b/src/client/java/io/github/ueva/cluescrollhud/net/RemoteDataFetcher.java
@@ -1,0 +1,63 @@
+package io.github.ueva.cluescrollhud.net;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.github.ueva.cluescrollhud.VgClueScrollHUD;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+
+
+public class RemoteDataFetcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VgClueScrollHUD.MOD_ID);
+    private static final String BASE_URL = "https://ueva.dev/api/vgcluescroll";
+    private static final Gson gson = new Gson();
+
+    private static long extendedExpiryTime = -1L;
+
+    public static void fetchAll() {
+        CompletableFuture.runAsync(() -> {
+            fetchExtendedExpiryTime();
+            LOGGER.info("- Fetched extended expiry time: {}", extendedExpiryTime);
+        });
+    }
+
+    private static void fetchExtendedExpiryTime() {
+
+        URI uri = URI.create(BASE_URL + "/extended/expiry");
+
+        try {
+            URL url = uri.toURL();
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("User-Agent", VgClueScrollHUD.MOD_ID);
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(3000);
+            conn.setReadTimeout(3000);
+
+            try (InputStreamReader reader = new InputStreamReader(conn.getInputStream())) {
+                JsonObject json = gson.fromJson(reader, JsonObject.class);
+                if (json.has("expiry") && json.get("expiry").isJsonPrimitive()) {
+                    extendedExpiryTime = json.get("expiry").getAsLong();
+                }
+                else {
+                    LOGGER.warn("Unexpected response format from {}. Expected Long, but got: {}", uri, json);
+                }
+            }
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to fetch extended expiry time from {}", uri);
+            LOGGER.error("Error: {}", e.toString());
+        }
+    }
+
+    public static long getExtendedExpiryTime() {
+        return extendedExpiryTime;
+    }
+
+}


### PR DESCRIPTION
Extended scrolls do not have expiry data attached to them - their expiration time is announced in the Discord server. This pull requests adds a feature that fetches the latest extended scroll's expiry time from an API endpoint, which will be updated whenever a new extended scroll is added/the expiry time is changed.

This seemed like the cleanest solution - I didn't want users to have to update the mod every time a new extended scroll is released, or the expiry time is pushed back.